### PR TITLE
Fixed StreetViewPanorama position handler referring to 'undefined' in…

### DIFF
--- a/src/components/streetViewPanoramaImpl.js
+++ b/src/components/streetViewPanoramaImpl.js
@@ -75,9 +75,9 @@ export default {
   watch: {
     position: {
       deep: true,
-      handler: latlngChangedHandler((val, oldVal) => {
+      handler: latlngChangedHandler(function(val, oldVal) {
         if (this.$panoObject) {
-          this.$panoObject.setCenter(val);
+          this.$panoObject.setPosition(val);
         }
       }),
     },


### PR DESCRIPTION
Fixed StreetViewPanorama position handler referring to 'undefined' instead of 'this'

Replaced call to non-existent 'setCenter' with 'setPosition' on $panoObject (google.maps.StreetViewPanorama)

You can find the issue being addressed here https://github.com/xkjyeah/vue-google-maps/blob/vue2/dist/components/streetViewPanoramaImpl.js#L110-L111