### PR TITLE
Initialisation error

### DIFF
--- a/src/components/cluster.js
+++ b/src/components/cluster.js
@@ -87,7 +87,8 @@ export default {
         marker.$clusterObject = null
       }
     })
-
-    this.$clusterObject.clearMarkers();
+    if (this.$clusterObject) {
+      this.$clusterObject.clearMarkers();
+    }
   },
 };


### PR DESCRIPTION
Sometimes the component doesn't instantiate $clusterObject before beforeDestroy is called.