### PR TITLE
Fixed the NPM example on the API page.

### DIFF
--- a/API.md
+++ b/API.md
@@ -328,15 +328,13 @@ Write your Vue component
   }
 </style>
 <div id="app">
-  <div class="map-container">
-    <gmap-map :center="{lat:1.38, lng:103.8}" :zoom="12">
-      <gmap-marker :position="{lat:1.38, lng:103.8}">
-      </gmap-marker>
-      <gmap-info-window :position="{lat:1.38, lng:103.8}">
-        Hello world!
-      </gmap-info-window>
-    </gmap-map>
-  </div>
+  <gmap-map class="map-container" :center="{lat:1.38, lng:103.8}" :zoom="12">
+    <gmap-marker :position="{lat:1.38, lng:103.8}">
+    </gmap-marker>
+    <gmap-info-window :position="{lat:1.38, lng:103.8}">
+      Hello world!
+    </gmap-info-window>
+  </gmap-map>
 </div>
 <script>
 new Vue({


### PR DESCRIPTION
The npm example does not work as the extra div causes the inner gmap element to have no height or width (so the map doesn't render). This pull request fixes that by removing the extra div element from the example.