### PR TITLE
append the google maps script tag to the page header.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -89,7 +89,7 @@ export const load = (apiKey, version, libraries, loadCn) => {
     googleMapScript.setAttribute('src', url)
     googleMapScript.setAttribute('async', '')
     googleMapScript.setAttribute('defer', '')
-    document.body.appendChild(googleMapScript)
+    document.head.appendChild(googleMapScript)
   } else {
     throw new Error('You already started the loading of google maps')
   }


### PR DESCRIPTION
Appending the google maps script tag to the header allows things to work more harmoniously with libraries like turbolinks, and probably will not hurt anything else. 