### PR TITLE
Repaint clusters only once after markers are changed

### DIFF
--- a/src/components/cluster.js
+++ b/src/components/cluster.js
@@ -83,6 +83,10 @@ export default {
     eventsBinder(this, this.$clusterObject, events)
   },
 
+  updated () {
+    this.$clusterObject.repaint()
+  },
+
   beforeDestroy () {
     /* Performance optimization when destroying a large number of markers */
     this.$children.forEach(marker => {

--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -109,7 +109,7 @@ export default {
     if (!this.$markerObject) { return }
 
     if (this.$clusterObject) {
-      this.$clusterObject.removeMarker(this.$markerObject)
+      this.$clusterObject.removeMarker(this.$markerObject, true)
     } else {
       this.$markerObject.setMap(null)
     }


### PR DESCRIPTION
The destroy hook of the markers removes the marker from the cluster
object which triggers a repaint for each marker that is destoyed. This
severly degrades performance when a large number of markers is involved.
This is fixed by suppressing the repaint during destruction of the
markers and explicitly calling repaint() in the cluster update hook.

Fixes#178