### PR TITLE
Update polyline.js

### DIFF
--- a/src/components/polyline.js
+++ b/src/components/polyline.js
@@ -70,7 +70,8 @@ export default mapElementFactory({
         }
       }
     }, {
-      deep: this.deepWatch
+      deep: this.deepWatch,
+      immediate: true,
     })
   }
 })


### PR DESCRIPTION
Adding `immediate: true` to watcher.
Fixes not working `path_changed` event on Polyline.
https://github.com/xkjyeah/vue-google-maps/pull/429 without `dist`