### PR TITLE
Add GmapApi check to prevent crash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -120,5 +120,5 @@ function makeGmapApiPromiseLazy (options) {
 }
 
 export function gmapApi () {
-  return GmapApi.gmapApi && window.google
+  return GmapApi && GmapApi.gmapApi && window.google
 }


### PR DESCRIPTION
Right now, when the `gmapApi` is called and the api is not loaded yet, it crashes since GmapApi is null (thus GmapApi.gmapApi doesn't exists).

This could happen, for example, when you need to access it on the mounted hook:

```javascript
import { gmapApi } from 'vue2-google-maps'

export default {
  computed: {
    google: gmapApi
  },
  mounted() {
    this.google...
  }
}
```

This PR solves this issue just by checking the existence of GmapApi