### PR TITLE
Re-add the babelify configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,11 @@
     "yaml-loader": "^0.5.0"
   },
   "author": "Daniel Sim, Guillaume Leclerc",
-  "license": "MIT"
+  "license": "MIT",
+  "browserify": {
+    "transform": [
+      "babelify",
+      "vueify"
+    ]
+  }
 }


### PR DESCRIPTION
As stated in the babelify FAQ we need the configuration for browserify
inside of the packages own package.json.

* https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed

For testing I used this repository and added vue2-google-maps as a
dependency:

* https://github.com/makyo-dev/vue2-gulp-example

Resolves: #434