### PR TITLE
Change China maps api from http to https

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -52,10 +52,10 @@ export const loadGmapApi = (options, loadCn) => {
     }
     options['callback'] = 'vueGoogleMapsInit'
 
-    let baseUrl = 'https://maps.googleapis.com/'
+    let baseUrl = '//maps.googleapis.com/'
 
     if (typeof loadCn === 'boolean' && loadCn === true) {
-      baseUrl = 'http://maps.google.cn/'
+      baseUrl = '//maps.google.cn/'
     }
 
     let url = baseUrl + 'maps/api/js?' +

--- a/src/manager.js
+++ b/src/manager.js
@@ -52,10 +52,10 @@ export const loadGmapApi = (options, loadCn) => {
     }
     options['callback'] = 'vueGoogleMapsInit'
 
-    let baseUrl = '//maps.googleapis.com/'
+    let baseUrl = 'https://maps.googleapis.com/'
 
     if (typeof loadCn === 'boolean' && loadCn === true) {
-      baseUrl = '//maps.google.cn/'
+      baseUrl = 'https://maps.google.cn/'
     }
 
     let url = baseUrl + 'maps/api/js?' +


### PR DESCRIPTION
I tested https access from a vm located in China(mainland), and seems to work fine, so I'm guessing google has updated its api to support this.