### PR TITLE
Add support for average center marker clustering

### DIFF
--- a/src/components/cluster.js
+++ b/src/components/cluster.js
@@ -31,6 +31,10 @@ const props = {
     type: Number,
     twoWay: false
   },
+  averageCenter: {
+    type: Boolean,
+    twoWay: false
+  },
   ignoreHidden: {
     type: Boolean,
     twoWay: false


### PR DESCRIPTION
Controls whether the position of a cluster marker should be the average
position of all markers in the cluster (defaults to the position of the
first marker in the cluster).

This is a useful feature of the `markerclusterer`.