### PR TITLE
Bug Fixes in ReadME documentation & Code Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Vue.use(VueGoogleMaps, {
   //// If you want to manually install components, e.g.
   //// import {GmapMarker} from 'vue2-google-maps/src/components/marker'
   //// Vue.component('GmapMarker', GmapMarker)
-  //// then disable the following:
-  // installComponents: true,
+  //// then set installComponents to 'false'.
+  //// If you want to automatically install all the components this property must be set to 'true':
+  installComponents: true
 })
 ```
 

--- a/examples/infowindow.html
+++ b/examples/infowindow.html
@@ -4,7 +4,6 @@
 
     <gmap-map :center="center" :zoom="15" style="width: 100%; height: 500px">
       <gmap-info-window :options="infoOptions" :position="infoWindowPos" :opened="infoWinOpen" @closeclick="infoWinOpen=false">
-        {{infoContent}}
       </gmap-info-window>
 
       <gmap-marker :key="i" v-for="(m,i) in markers" :position="m.position" :clickable="true" @click="toggleInfoWindow(m,i)"></gmap-marker>
@@ -29,12 +28,13 @@
             lat: 47.376332,
             lng: 8.547511
           },
-          infoContent: '',
           infoWindowPos: null,
           infoWinOpen: false,
           currentMidx: null,
-          //optional: offset infowindow so it visually sits nicely on top of our marker
+
           infoOptions: {
+        	content: '',
+            //optional: offset infowindow so it visually sits nicely on top of our marker
             pixelOffset: {
               width: 0,
               height: -35
@@ -45,25 +45,25 @@
               lat: 47.376332,
               lng: 8.547511
             },
-            infoText: 'Marker 1'
+            infoText: '<strong>Marker 1</strong>'
           }, {
             position: {
               lat: 47.374592,
               lng: 8.548867
             },
-            infoText: 'Marker 2'
+            infoText: '<strong>Marker 2</strong>'
           }, {
             position: {
               lat: 47.379592,
               lng: 8.549867
             },
-            infoText: 'Marker 3'
+            infoText: '<strong>Marker 3</strong>'
           }]
         },
         methods: {
           toggleInfoWindow: function(marker, idx) {
             this.infoWindowPos = marker.position;
-            this.infoContent = marker.infoText;
+            this.infoOptions.content = marker.infoText;
 
             //check if its the same marker that was selected if yes toggle
             if (this.currentMidx == idx) {

--- a/examples/infowindow.html
+++ b/examples/infowindow.html
@@ -4,7 +4,6 @@
 
     <gmap-map :center="center" :zoom="15" style="width: 100%; height: 500px">
       <gmap-info-window :options="infoOptions" :position="infoWindowPos" :opened="infoWinOpen" @closeclick="infoWinOpen=false">
-        {{infoContent}}
       </gmap-info-window>
 
       <gmap-marker :key="i" v-for="(m,i) in markers" :position="m.position" :clickable="true" @click="toggleInfoWindow(m,i)"></gmap-marker>
@@ -29,12 +28,13 @@
             lat: 47.376332,
             lng: 8.547511
           },
-          infoContent: '',
           infoWindowPos: null,
           infoWinOpen: false,
           currentMidx: null,
-          //optional: offset infowindow so it visually sits nicely on top of our marker
+
           infoOptions: {
+        	content: '',
+            //optional: offset infowindow so it visually sits nicely on top of our marker
             pixelOffset: {
               width: 0,
               height: -35
@@ -63,7 +63,7 @@
         methods: {
           toggleInfoWindow: function(marker, idx) {
             this.infoWindowPos = marker.position;
-            this.infoContent = marker.infoText;
+            this.infoOptions.content = marker.infoText;
 
             //check if its the same marker that was selected if yes toggle
             if (this.currentMidx == idx) {


### PR DESCRIPTION
In order for this plugin to install all components automatically the
'installComponents' attribute must be explicitly set to true. 
This was not clear in the documentation because the necessary line to correctly
set this attribute in the documentation example was commented out, implying that the
attribute did not need to be included. This is confusing for developers during initial integration.