### PR TITLE
Removal of @babel/runtime package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -786,15 +786,6 @@
         "semver": "^5.5.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
-      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@babel/core": "^7.5.4",
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.4",
-    "@babel/runtime": "^7.5.4",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
     "babel-plugin-minify-dead-code-elimination": "^0.4.3",


### PR DESCRIPTION
As the name of the package implies, is to be used in runtime, i.e., is to be set in dependencies and not in devDependencies. This is indicated in [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime).

Instead of moving this to the vue-google-maps dependencies and increasing the production image, it's better to remove it, as it does not add anything of value to a package that is meant to be used with a build environement like Webpack, that will handle the poyfills and transpilation for you.