### PR TITLE
Removed runtimeChunk and mini-css-extract-plugin

### DIFF
--- a/config/webpack.production.config.js
+++ b/config/webpack.production.config.js
@@ -1,7 +1,6 @@
 const path = require('path')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 
 const config = {
@@ -9,18 +8,11 @@ const config = {
     path.resolve('./src/main.js')
   ],
   optimization: {
-    runtimeChunk: {
-      name: 'runtime'
-    },
     minimizer: [
       new UglifyJsPlugin({
         cache: true,
         parallel: true,
         sourceMap: true
-      }),
-      new MiniCssExtractPlugin({
-        filename: '[name].[hash].css',
-        chunkFilename: '[id].[hash].css'
       }),
       new OptimizeCSSAssetsPlugin({})
     ]
@@ -44,7 +36,7 @@ const config = {
       {
         test: /\.(css)$/,
         use: [
-          MiniCssExtractPlugin.loader,
+          'style-loader',
           'css-loader']
       },
       {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "gh-pages": "^1.2.0",
     "json-loader": "^0.5.7",
     "lab": "^18.0.2",
-    "mini-css-extract-plugin": "^0.4.5",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "puppeteer": "^1.18.1",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
Changes:
- Removed `runtimeChunk` because it generate the error `VueGoogleMaps is not defined`
- Removed `MiniCssExtractPlugin` because it cause that the map not load correctly.

Related issue:
- #632 