### PR TITLE
checks on window.google

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -33,6 +33,12 @@ export const loadGmapApi = (options, loadCn) => {
     // Do nothing if run from server-side
     return
   }
+
+  if(!!window.google) {
+    // Do nothing if window.google is alreay exists
+    return
+  }
+
   if (!isApiSetUp) {
     isApiSetUp = true
 


### PR DESCRIPTION
if other libraries included google we should avoid adding another one while google shout an error for re-register of window.google