### PR TITLE
Added ability to customize input using input named scoped slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+# How it differs to https://github.com/xkjyeah/vue-google-maps
+
+The autocomplete supports cutsom text field via scoped slot
+
+```html
+          <gmap-autocomplete class="introInput" >
+                    <template v-slot:input="slotProps">
+                        <v-text-field outlined 
+                                      prepend-inner-icon="place" 
+                                      placeholder="Location Of Event" 
+                                      ref="input" 
+                                      v-on:listeners="slotProps.listeners" 
+                                      v-on:attrs="slotProps.attrs">
+                        </v-text-field>
+                    </template>
+        </gmap-autocomplete>
+```
+
+The ref on the element must be called input, if the element is a vue component then it must have a child ref called input (like in vuetify text-field) or speciy a custom name via childRefName property (only works one level deep into a component).
+
+The v-on:listeners is rquired, v-on:attrs may or may not be required depending on your implementation.
+
+This requires vue 2.6 or higher for the new slot support.
+
+
 # CONTRIBUTORS NEEDED!
 
 It's been increasingly difficult for me to make time to maintain this project.

--- a/src/components-implementation/autocomplete.js
+++ b/src/components-implementation/autocomplete.js
@@ -26,6 +26,12 @@ const props = {
     type: Boolean,
     default: false
   },
+  // the name of the ref to obtain the input (if its a child  of component in the slot)
+  childRefName: {
+    required: false,
+    type: String,
+    default: 'input'
+    },
   options: {
     type: Object
   }
@@ -34,6 +40,14 @@ const props = {
 export default {
   mounted () {
     this.$gmapApiPromiseLazy().then(() => {
+      var scopedInput = null
+      if  (this.$scopedSlots.input)  {
+        scopedInput = this.$scopedSlots.input()[0].context.$refs.input
+        if (scopedInput && scopedInput.$refs) {
+          scopedInput = scopedInput.$refs[this.childRefName || 'input']
+        }
+        if (scopedInput) { this.$refs.input = scopedInput }
+      }
       if (this.selectFirstOnEnter) {
         downArrowSimulator(this.$refs.input)
       }

--- a/src/components/autocomplete.vue
+++ b/src/components/autocomplete.vue
@@ -1,9 +1,8 @@
 <template>
-  <input
-    ref="input"
-    v-bind="$attrs"
-    v-on="$listeners"
-    />
+  <span v-if="$scopedSlots['input']">
+    <slot name="input" v-bind:attrs="$attrs" v-bind:listeners="$listeners" :ref="input"></slot>
+  </span>
+  <input v-else-if="!$scopedSlots['input']" ref="input" v-bind="$attrs" v-on="$listeners" />
 </template>
 
 <script>


### PR DESCRIPTION
I found a way to make it very innocuous by making the original input outside the slot (and the wrapping span) and conditionally rendering the original input and the span depending on if the slot is specified.

So the following get the same render output as before the change
```html
 <gmap-autocomplete  @place_changed="processLocationChanged" 
         placeholder="Location Of Event" class="introInput">
        </gmap-autocomplete>
```

But this gets you a vuetify text field, wrapped in an unfortunately unavoidable (to the best of my knowledge) span.

```html
<!-- if using a component other than vuetify, specify childRefName="refNameOfHTMLInput" in gmap-autocomplete  -->
 <gmap-autocomplete  @place_changed="processLocationChanged"  
          placeholder="Location Of Event" class="introInput">
                    <!-- Be sure to use v-slot:input="" the slotProps can be
                     whatever you want but you must use that name in place of 
                    slotProps elsewhere in the slot -->
                    <template v-slot:input="slotProps">

                       <!-- ref="input" is requried
                       v-on:listeners="slotProps.listeners" is required, rename slotProps here if you did in v-slot:input="slotProps" above
                       v-on:attrs ="slotProps.attrs" may be required, rename slotProps here if you did in v-slot:input="slotProps" above 
                       -->
                        <v-text-field outlined prepend-inner-icon="place" 
                             placeholder="Location" 
                             ref="input"
                            v-on:listeners="slotProps.listeners"
                            v-on:attrs="slotProps.attrs">
                         </v-text-field>
                    </template>
        </gmap-autocomplete>
```

The only requirements are that v-on:listeners and ref be set, i don't know if attrs really needs to be set but im making it available in the scope anyway.

In this case vuetify puts a ref="input" on its internal text input, and the JS implementation will look for a $refs.input which firstly finds the vueitfy component, so if there is a .$refs on that it will look further and use the childRefName (eg slot.$refs.input.$refs[childRefName] (which defaults to input) to get the reference to the input element.