### PR TITLE
Autocomplete.setFields()

### DIFF
--- a/src/components-implementation/autocomplete.js
+++ b/src/components-implementation/autocomplete.js
@@ -75,11 +75,11 @@ export default {
           this.$autocomplete.setComponentRestrictions(v)
         }
       })
-      
+   
       // IMPORTANT: To avoid paying for data that you don't need,
       // be sure to use Autocomplete.setFields() to specify only the place data that you will use.
-      if(this.fields) {
-        this.$autocomplete.setFields(this.fields);
+      if (this.fields) {
+        this.$autocomplete.setFields(this.fields)
       }
 
       // Not using `bindEvents` because we also want

--- a/src/components-implementation/autocomplete.js
+++ b/src/components-implementation/autocomplete.js
@@ -78,8 +78,8 @@ export default {
       
       // IMPORTANT: To avoid paying for data that you don't need,
       // be sure to use Autocomplete.setFields() to specify only the place data that you will use.
-      if(_this.fields) {
-        _this.$autocomplete.setFields(_this.fields);
+      if(this.fields) {
+        this.$autocomplete.setFields(this.fields);
       }
 
       // Not using `bindEvents` because we also want

--- a/src/components-implementation/autocomplete.js
+++ b/src/components-implementation/autocomplete.js
@@ -34,6 +34,11 @@ const props = {
   },
   options: {
     type: Object
+  },
+  fields: {
+    required: false,
+    type: Array,
+    default: null
   }
 }
 
@@ -70,6 +75,12 @@ export default {
           this.$autocomplete.setComponentRestrictions(v)
         }
       })
+      
+      // IMPORTANT: To avoid paying for data that you don't need,
+      // be sure to use Autocomplete.setFields() to specify only the place data that you will use.
+      if(_this.fields) {
+        _this.$autocomplete.setFields(_this.fields);
+      }
 
       // Not using `bindEvents` because we also want
       // to return the result of `getPlace()`


### PR DESCRIPTION
By default, when a user selects a place, autocomplete returns all of the available data fields for the selected place, and you will be billed accordingly. Use Autocomplete.setFields() to specify which place data fields to return. Read more about the PlaceResult object, including a list of place data fields that you can request. To avoid paying for data that you don't need, be sure to use Autocomplete.setFields() to specify only the place data that you will use.