### PR TITLE
Fix spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Example of [MapOptions](https://developers.google.com/maps/documentation/javascr
     streetViewControl: false,
     rotateControl: false,
     fullscreenControl: true,
-    disableDefaultUi: false
+    disableDefaultUI: false
   }"
 >
 </GmapMap>


### PR DESCRIPTION
The setting to disable the default google maps UI should be spelled with a capital I at the end.