### PR TITLE
fixed: google maps for china

### DIFF
--- a/src/manager/initializer.js
+++ b/src/manager/initializer.js
@@ -59,7 +59,7 @@ export default (() => {
       let baseUrl = 'https://maps.googleapis.com/'
 
       if (typeof loadCn === 'boolean' && loadCn === true) {
-        baseUrl = 'https://maps.google.cn/'
+        baseUrl = 'https://www.google.cn//'
       }
 
       const query = Object.keys(options)


### PR DESCRIPTION
https://www.google.cn//maps instead of https://maps.google.cn/maps