### PR TITLE
Update cluster.js to include clusterClass

### DIFF
--- a/src/components/cluster.js
+++ b/src/components/cluster.js
@@ -62,7 +62,11 @@ const props = {
   zoomOnClick: {
     type: Boolean,
     twoWay: false
-  }
+  },
+  clusterClass: {
+  	type: String,
+  	twoWay: false
+  },
 }
 
 const events = [


### PR DESCRIPTION
Add the `clusterClass` attribute so it can be set as an option.

Setting the clusterClass didn't always work using the default `:options` attribute. This allows for the clusterClass to be added by using `:cluster-class="classNameString"` on the GmapCluster component.